### PR TITLE
Updated for PHP 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+composer.phar
+vendor

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "respect/validation": "0.8.*",
+        "respect/validation": "^1.1",
         "guzzlehttp/guzzle": "~5.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,343 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "c4901b44b258374175f8186710870052",
+    "packages": [
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "5.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "70f1fa53b71c4647bf2762c09068a95f77e12fb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/70f1fa53b71c4647bf2762c09068a95f77e12fb8",
+                "reference": "70f1fa53b71c4647bf2762c09068a95f77e12fb8",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/ringphp": "^1.1",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2016-07-15T19:28:39+00:00"
+        },
+        {
+            "name": "guzzlehttp/ringphp",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/RingPHP.git",
+                "reference": "dbbb91d7f6c191e5e405e900e3102ac7f261bc0b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/dbbb91d7f6c191e5e405e900e3102ac7f261bc0b",
+                "reference": "dbbb91d7f6c191e5e405e900e3102ac7f261bc0b",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/streams": "~3.0",
+                "php": ">=5.4.0",
+                "react/promise": "~2.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "ext-curl": "Guzzle will use specific adapters if cURL is present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Ring\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
+            "time": "2015-05-20T03:37:09+00:00"
+        },
+        {
+            "name": "guzzlehttp/streams",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/streams.git",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple abstraction over streams of data",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "Guzzle",
+                "stream"
+            ],
+            "time": "2014-10-12T19:18:40+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v2.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "62785ae604c8d69725d693eb370e1d67e94c4053"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/62785ae604c8d69725d693eb370e1d67e94c4053",
+                "reference": "62785ae604c8d69725d693eb370e1d67e94c4053",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "time": "2017-03-25T12:08:31+00:00"
+        },
+        {
+            "name": "respect/validation",
+            "version": "1.1.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Respect/Validation.git",
+                "reference": "22f1f14430155c21c1d6ba271a652f28c5057851"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Respect/Validation/zipball/22f1f14430155c21c1d6ba271a652f28c5057851",
+                "reference": "22f1f14430155c21c1d6ba271a652f28c5057851",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "symfony/polyfill-mbstring": "^1.2"
+            },
+            "require-dev": {
+                "egulias/email-validator": "~1.2",
+                "malkusch/bav": "~1.0",
+                "mikey179/vfsstream": "^1.5",
+                "phpunit/phpunit": "~4.0",
+                "symfony/validator": "~2.6.9",
+                "zendframework/zend-validator": "~2.3"
+            },
+            "suggest": {
+                "egulias/email-validator": "Strict (RFC compliant) email validation",
+                "ext-bcmath": "Arbitrary Precision Mathematics",
+                "ext-mbstring": "Multibyte String Functions",
+                "fabpot/php-cs-fixer": "Fix PSR2 and other coding style issues",
+                "malkusch/bav": "German bank account validation",
+                "symfony/validator": "Use Symfony validator through Respect\\Validation",
+                "zendframework/zend-validator": "Use Zend Framework validator through Respect\\Validation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Respect\\Validation\\": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD Style"
+            ],
+            "authors": [
+                {
+                    "name": "Respect/Validation Contributors",
+                    "homepage": "https://github.com/Respect/Validation/graphs/contributors"
+                }
+            ],
+            "description": "The most awesome validation engine ever created for PHP",
+            "homepage": "http://respect.github.io/Validation/",
+            "keywords": [
+                "respect",
+                "validation",
+                "validator"
+            ],
+            "time": "2017-10-17T10:15:51+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2017-10-11T12:05:26+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.4.0"
+    },
+    "platform-dev": []
+}

--- a/src/Sircamp/Xenapi/Connection/XenConnection.php
+++ b/src/Sircamp/Xenapi/Connection/XenConnection.php
@@ -2,286 +2,307 @@
 
 use Respect\Validation\Validator as Validator;
 use GuzzleHttp\Client as Client;
-use Sircamp\Xenapi\Exception\XenConnectionException as  XenConnectionException;
+use Sircamp\Xenapi\Exception\XenConnectionException as XenConnectionException;
 
-class XenConnection {
-	
+class XenConnection
+{
+
 
 	private $url;
 	private $session_id;
 	private $user;
 	private $password;
 
-	function __construct(){
-    
-        $this->session_id = null;
-        $this->url = null;
-        $this->user = null;
-        $this->password = null;
+	function __construct()
+	{
 
-    }
+		$this->session_id = null;
+		$this->url        = null;
+		$this->user       = null;
+		$this->password   = null;
 
-    /**
-     * Gets the value of url.
-     *
-     * @return mixed
-     */
-    public function getUrl()
-    {
-        return $this->url;
-    }
+	}
 
-    /**
-     * Sets the value of url.
-     *
-     * @param mixed $url the url
-     *
-     * @return self
-     */
-    private function _setUrl($url)
-    {
-        $this->url = $url;
+	/**
+	 * Gets the value of url.
+	 *
+	 * @return mixed
+	 */
+	public function getUrl()
+	{
+		return $this->url;
+	}
 
-        return $this;
-    }
+	/**
+	 * Sets the value of url.
+	 *
+	 * @param mixed $url the url
+	 *
+	 * @return self
+	 */
+	private function _setUrl($url)
+	{
+		$this->url = $url;
 
-    /**
-     * Gets the value of session_id.
-     *
-     * @return mixed
-     */
-    public function getSessionId()
-    {
-        return $this->session_id;
-    }
+		return $this;
+	}
 
-    /**
-     * Sets the value of session_id.
-     *
-     * @param mixed $session_id the session id
-     *
-     * @return self
-     */
-    private function _setSessionId($session_id)
-    {
-        $this->session_id = $session_id;
+	/**
+	 * Gets the value of session_id.
+	 *
+	 * @return mixed
+	 */
+	public function getSessionId()
+	{
+		return $this->session_id;
+	}
 
-        return $this;
-    }
+	/**
+	 * Sets the value of session_id.
+	 *
+	 * @param mixed $session_id the session id
+	 *
+	 * @return self
+	 */
+	private function _setSessionId($session_id)
+	{
+		$this->session_id = $session_id;
 
-    /**
-     * Gets the value of user.
-     *
-     * @return mixed
-     */
-    public function getUser()
-    {
-        return $this->user;
-    }
+		return $this;
+	}
 
-    /**
-     * Sets the value of user.
-     *
-     * @param mixed $user the user
-     *
-     * @return self
-     */
-    private function _setUser($user)
-    {
-        $this->user = $user;
+	/**
+	 * Gets the value of user.
+	 *
+	 * @return mixed
+	 */
+	public function getUser()
+	{
+		return $this->user;
+	}
 
-        return $this;
-    }
+	/**
+	 * Sets the value of user.
+	 *
+	 * @param mixed $user the user
+	 *
+	 * @return self
+	 */
+	private function _setUser($user)
+	{
+		$this->user = $user;
 
-    /**
-     * Gets the value of password.
-     *
-     * @return mixed
-     */
-    public function getPassword()
-    {
-        return $this->password;
-    }
+		return $this;
+	}
 
-    /**
-     * Sets the value of password.
-     *
-     * @param mixed $password the password
-     *
-     * @return self
-     */
-    private function _setPassword($password)
-    {
-        $this->password = $password;
+	/**
+	 * Gets the value of password.
+	 *
+	 * @return mixed
+	 */
+	public function getPassword()
+	{
+		return $this->password;
+	}
 
-        return $this;
-    }
+	/**
+	 * Sets the value of password.
+	 *
+	 * @param mixed $password the password
+	 *
+	 * @return self
+	 */
+	private function _setPassword($password)
+	{
+		$this->password = $password;
 
-     /**
-     * Sets all values of object.
-     *
-     * @param mixed $password the password, mixed $url the url, 
-     * 		  mixed $session_id the session_id and mixed 4user the user
-     *
-     * @return self
-     */
+		return $this;
+	}
 
-    function _setAll($url,$session_id,$user,$password){
+	/**
+	 * Sets all values of object.
+	 *
+	 * @param mixed $password the password, mixed $url the url,
+	 *                        mixed $session_id the session_id and mixed 4user the user
+	 *
+	 * @return self
+	 */
 
-    	$this->_setPassword($password);
-    	$this->_setSessionId($session_id);
-    	$this->_setUrl($url);
-    	$this->_setUser($user);
-     	return $this;
-    }
+	function _setAll($url, $session_id, $user, $password)
+	{
 
-    /**
-    * Sets and initialize xen server connection
-    *
-    * @param mixed $url the ip, mixed $user the user and mixed $password the password, 
-    *         
-    *
-    * @return XenResponse
-    */
+		$this->_setPassword($password);
+		$this->_setSessionId($session_id);
+		$this->_setUrl($url);
+		$this->_setUser($user);
 
-    function _setServer($url, $user, $password) {
-        
-        $response = $this->xenrpc_request($url, $this->xenrpc_method('session.login_with_password', array($user, $password, '1.3.1')));
-        
-        if(Validator::arrayType()->validate($response) && Validator::key('Status', Validator::equals('Success'))->validate($response)){
-           	
-           	$this->_setAll($url,$response['Value'],$user,$password);
-           	
-        } 
-        else {
-            
-            throw new XenConnectionException("Error during contact Xen, check your credentials (user, password and ip)", 1);
-            
-        }
-    }
+		return $this;
+	}
 
-    /**
-    * This parse the xml response and return the response obj
-    *
-    * @param mixed $response, 
-    *         
-    *
-    * @return XenResponse
-    */
+	/**
+	 * Sets and initialize xen server connection
+	 *
+	 * @param mixed $url the ip, mixed $user the user and mixed $password the password,
+	 *
+	 *
+	 * @return XenResponse
+	 */
 
-    function xenrpc_parseresponse($response) {
-        
-        
-        if (!Validator::arrayType()->validate($response) && !Validator::key('Status')->validate($response)) {
+	function _setServer($url, $user, $password)
+	{
 
-            return new XenResponse($response);
-        }
-        else {
-            
-            if (Validator::key('Status',Validator::equals('Success'))->validate($response)) {
-               	return new XenResponse($response);
-            } 
-            else {
-            
-               if ($response['ErrorDescription'][0] == 'SESSION_INVALID'){
-                   
-                   $response = $this->xenrpc_request($this->url, $this->xenrpc_method('session.login_with_password',
-                               array($this->user, $this->password, '1.3.1')));
-                   
-                   if(Validator::arrayType()->validate($response) && Validator::key('Status', Validator::equals('Success'))->validate($response)){
-                       $this->_setSessionId($response['Value']);
-                   }
-                   else {
-                       return new XenResponse($response);
-                   }
-               } 
-               else {
-                    return new XenResponse($response);
-                   
-               }
-            }
-        }
+		$response = $this->xenrpc_request($url, $this->xenrpc_method('session.login_with_password', array($user, $password, '1.3.1')));
 
-        
-        return new XenResponse($response);
-    }
-    
+		if (Validator::arrayType()->validate($response) && Validator::key('Status', Validator::equals('Success'))->validate($response))
+		{
 
-    /**
-    * This encode the request into a xml_rpc
-    *
-    * @param mixed $name the method name and mixed $params the arguments, 
-    *         
-    *
-    * @return mixed
-    */
+			$this->_setAll($url, $response['Value'], $user, $password);
 
-    function xenrpc_method($name, $params) {
-        
-        $encoded_request = xmlrpc_encode_request($name, $params);
-
-        return $encoded_request;
-    }
-
-
-    /**
-    * This make the curl request for comunicate to xen
-    *
-    * @param mixed $usr the url and mixed $req the request, 
-    *         
-    *
-    * @return XenResponse
-    */
-
-    function xenrpc_request($url, $req) {
-        
-    	$client = new Client();
-        
-        $response = $client->post($url,
-          [
-
-            'headers' => [
-              'Content-type' => 'text/xml',
-              'Content-length' => strlen($req),
-              ],
-            'body' => $req,
-            'timeout' => 60,
-            'verify' => FALSE,
-
-          ]);
-
-        $body = $response->getBody();
-        $xml ="";
-        while (!$body->eof()) {
-    		$xml .= $body->read(1024);
 		}
-        
-        
-        return xmlrpc_decode($xml);
-    }
+		else
+		{
+
+			throw new XenConnectionException("Error during contact Xen, check your credentials (user, password and ip)", 1);
+
+		}
+	}
+
+	/**
+	 * This parse the xml response and return the response obj
+	 *
+	 * @param mixed $response ,
+	 *
+	 *
+	 * @return XenResponse
+	 */
+
+	function xenrpc_parseresponse($response)
+	{
 
 
-    /**
-    * This halde every non-declared class method called on XenConnectionObj
-    *
-    * @param mixed $name the name of method and $args the argument of method, 
-    *         
-    *
-    * @return XenResponse
-    */
+		if (!Validator::arrayType()->validate($response) && !Validator::key('Status')->validate($response))
+		{
 
-    function __call($name, $args) {
-        
-        if (!Validator::arrayType()->validate($args)) {
-            $args = array();
-        }
-        
-        list($mod, $method) = explode('__', $name);
-        $response = $this->xenrpc_parseresponse($this->xenrpc_request($this->getUrl(), 
-                  $this->xenrpc_method($mod . '.' . $method, array_merge(array($this->getSessionId()), $args))));
-       
-        return $response;
-    }
+			return new XenResponse($response);
+		}
+		else
+		{
+
+			if (Validator::key('Status', Validator::equals('Success'))->validate($response))
+			{
+				return new XenResponse($response);
+			}
+			else
+			{
+
+				if ($response['ErrorDescription'][0] == 'SESSION_INVALID')
+				{
+
+					$response = $this->xenrpc_request($this->url, $this->xenrpc_method('session.login_with_password',
+						array($this->user, $this->password, '1.3.1')));
+
+					if (Validator::arrayType()->validate($response) && Validator::key('Status', Validator::equals('Success'))->validate($response))
+					{
+						$this->_setSessionId($response['Value']);
+					}
+					else
+					{
+						return new XenResponse($response);
+					}
+				}
+				else
+				{
+					return new XenResponse($response);
+
+				}
+			}
+		}
+
+
+		return new XenResponse($response);
+	}
+
+
+	/**
+	 * This encode the request into a xml_rpc
+	 *
+	 * @param mixed $name the method name and mixed $params the arguments,
+	 *
+	 *
+	 * @return mixed
+	 */
+
+	function xenrpc_method($name, $params)
+	{
+
+		$encoded_request = xmlrpc_encode_request($name, $params);
+
+		return $encoded_request;
+	}
+
+
+	/**
+	 * This make the curl request for comunicate to xen
+	 *
+	 * @param mixed $usr the url and mixed $req the request,
+	 *
+	 *
+	 * @return XenResponse
+	 */
+
+	function xenrpc_request($url, $req)
+	{
+
+		$client = new Client();
+
+		$response = $client->post($url,
+			[
+
+				'headers' => [
+					'Content-type'   => 'text/xml',
+					'Content-length' => strlen($req),
+				],
+				'body'    => $req,
+				'timeout' => 60,
+				'verify'  => false,
+
+			]);
+
+		$body = $response->getBody();
+		$xml  = "";
+		while (!$body->eof())
+		{
+			$xml .= $body->read(1024);
+		}
+
+
+		return xmlrpc_decode($xml);
+	}
+
+
+	/**
+	 * This halde every non-declared class method called on XenConnectionObj
+	 *
+	 * @param mixed $name the name of method and $args the argument of method,
+	 *
+	 *
+	 * @return XenResponse
+	 */
+
+	function __call($name, $args)
+	{
+
+		if (!Validator::arrayType()->validate($args))
+		{
+			$args = array();
+		}
+
+		list($mod, $method) = explode('__', $name);
+		$response = $this->xenrpc_parseresponse($this->xenrpc_request($this->getUrl(),
+			$this->xenrpc_method($mod . '.' . $method, array_merge(array($this->getSessionId()), $args))));
+
+		return $response;
+	}
 
 }
 

--- a/src/Sircamp/Xenapi/Connection/XenConnection.php
+++ b/src/Sircamp/Xenapi/Connection/XenConnection.php
@@ -148,7 +148,7 @@ class XenConnection {
         
         $response = $this->xenrpc_request($url, $this->xenrpc_method('session.login_with_password', array($user, $password, '1.3.1')));
         
-        if(Validator::arr()->validate($response) && Validator::key('Status', Validator::equals('Success'))->validate($response)){
+        if(Validator::arrayType()->validate($response) && Validator::key('Status', Validator::equals('Success'))->validate($response)){
            	
            	$this->_setAll($url,$response['Value'],$user,$password);
            	
@@ -172,7 +172,7 @@ class XenConnection {
     function xenrpc_parseresponse($response) {
         
         
-        if (!Validator::arr()->validate($response) && !Validator::key('Status')->validate($request)) {
+        if (!Validator::arrayType()->validate($response) && !Validator::key('Status')->validate($response)) {
 
             return new XenResponse($response);
         }
@@ -185,10 +185,10 @@ class XenConnection {
             
                if ($response['ErrorDescription'][0] == 'SESSION_INVALID'){
                    
-                   $response = $this->xenrpc_request($url, $this->xenrpc_method('session.login_with_password', 
-                               array($this->_user, $this->_password, '1.3.1')));
+                   $response = $this->xenrpc_request($this->url, $this->xenrpc_method('session.login_with_password',
+                               array($this->user, $this->password, '1.3.1')));
                    
-                   if(Validator::arr()->validate($response) && Validator::key('Status', Validator::equals('Success'))->validate($response)){
+                   if(Validator::arrayType()->validate($response) && Validator::key('Status', Validator::equals('Success'))->validate($response)){
                        $this->_setSessionId($response['Value']);
                    }
                    else {
@@ -272,7 +272,7 @@ class XenConnection {
 
     function __call($name, $args) {
         
-        if (!Validator::arr()->validate($args)) {
+        if (!Validator::arrayType()->validate($args)) {
             $args = array();
         }
         

--- a/src/Sircamp/Xenapi/Connection/XenResponse.php
+++ b/src/Sircamp/Xenapi/Connection/XenResponse.php
@@ -4,95 +4,98 @@ use ReflectionClass;
 use Respect\Validation\Validator as Validator;
 use GuzzleHttp\Client as Client;
 
-class XenResponse {
-	
+class XenResponse
+{
+
 	private $Value;
 	private $Status;
 	private $ErrorDescription = array();
-	
-	public function __construct($args){
 
-		foreach ($args as $key => $argument) {
-			$class = new ReflectionClass('Sircamp\Xenapi\Connection\XenResponse');
-			$property  = $class->getProperty($key);
-			$property->setAccessible( true );
+	public function __construct($args)
+	{
+
+		foreach ($args as $key => $argument)
+		{
+			$class    = new ReflectionClass('Sircamp\Xenapi\Connection\XenResponse');
+			$property = $class->getProperty($key);
+			$property->setAccessible(true);
 			$property->setValue($this, $argument);
-			
+
 		}
 
 	}
 
-    /**
-     * Gets the value of Value.
-     *
-     * @return mixed
-     */
-    public function getValue()
-    {
-        return $this->Value;
-    }
+	/**
+	 * Gets the value of Value.
+	 *
+	 * @return mixed
+	 */
+	public function getValue()
+	{
+		return $this->Value;
+	}
 
-    /**
-     * Sets the value of Value.
-     *
-     * @param mixed $Value the value
-     *
-     * @return self
-     */
-    public function _setValue($Value)
-    {
-        $this->Value = $Value;
+	/**
+	 * Sets the value of Value.
+	 *
+	 * @param mixed $Value the value
+	 *
+	 * @return self
+	 */
+	public function _setValue($Value)
+	{
+		$this->Value = $Value;
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Gets the value of Status.
-     *
-     * @return mixed
-     */
-    public function getStatus()
-    {
-        return $this->Status;
-    }
+	/**
+	 * Gets the value of Status.
+	 *
+	 * @return mixed
+	 */
+	public function getStatus()
+	{
+		return $this->Status;
+	}
 
-    /**
-     * Sets the value of Status.
-     *
-     * @param mixed $Status the status
-     *
-     * @return self
-     */
-    private function _setStatus($Status)
-    {
-        $this->Status = $Status;
+	/**
+	 * Sets the value of Status.
+	 *
+	 * @param mixed $Status the status
+	 *
+	 * @return self
+	 */
+	private function _setStatus($Status)
+	{
+		$this->Status = $Status;
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Gets the value of ErrorDescription.
-     *
-     * @return mixed
-     */
-    public function getErrorDescription()
-    {
-        return $this->ErrorDescription;
-    }
+	/**
+	 * Gets the value of ErrorDescription.
+	 *
+	 * @return mixed
+	 */
+	public function getErrorDescription()
+	{
+		return $this->ErrorDescription;
+	}
 
-    /**
-     * Sets the value of ErrorDescription.
-     *
-     * @param mixed $ErrorDescription the error description
-     *
-     * @return self
-     */
-    private function _setErrorDescription($ErrorDescription)
-    {
-        $this->ErrorDescription = $ErrorDescription;
+	/**
+	 * Sets the value of ErrorDescription.
+	 *
+	 * @param mixed $ErrorDescription the error description
+	 *
+	 * @return self
+	 */
+	private function _setErrorDescription($ErrorDescription)
+	{
+		$this->ErrorDescription = $ErrorDescription;
 
-        return $this;
-    }
+		return $this;
+	}
 }
 
 ?>

--- a/src/Sircamp/Xenapi/Element/XenElement.php
+++ b/src/Sircamp/Xenapi/Element/XenElement.php
@@ -2,40 +2,43 @@
 
 use Respect\Validation\Validator as Validator;
 use GuzzleHttp\Client as Client;
-use Sircamp\Xenapi\Connection\XenConnection as  XenConnection;
+use Sircamp\Xenapi\Connection\XenConnection as XenConnection;
 
 
-class XenElement {
-	
+class XenElement
+{
+
 	private $xenconnection;
 
 
-	function __construct($xenconnection){
+	function __construct($xenconnection)
+	{
 		$this->xenconnection = $xenconnection;
 	}
 
-    /**
-     * Gets the value of xenconnection.
-     *
-     * @return mixed
-     */
-    public function getXenconnection()
-    {
-        return $this->xenconnection;
-    }
+	/**
+	 * Gets the value of xenconnection.
+	 *
+	 * @return mixed
+	 */
+	public function getXenconnection()
+	{
+		return $this->xenconnection;
+	}
 
-    /**
-     * Sets the value of xenconnection.
-     *
-     * @param mixed $xenconnection the xenconnection
-     *
-     * @return self
-     */
-    private function _setXenconnection($xenconnection)
-    {
-        $this->xenconnection = $xenconnection;
+	/**
+	 * Sets the value of xenconnection.
+	 *
+	 * @param mixed $xenconnection the xenconnection
+	 *
+	 * @return self
+	 */
+	private function _setXenconnection($xenconnection)
+	{
+		$this->xenconnection = $xenconnection;
 
-        return $this;
-    }
+		return $this;
+	}
 }
+
 ?>

--- a/src/Sircamp/Xenapi/Element/XenHost.php
+++ b/src/Sircamp/Xenapi/Element/XenHost.php
@@ -3,349 +3,373 @@
 use Respect\Validation\Validator as Validator;
 use GuzzleHttp\Client as Client;
 
-class XenHost extends XenElement {
+class XenHost extends XenElement
+{
 
 	private $name;
 	private $hostId;
 
-	public function __construct($xenconnection,$name,$hostId){
+	public function __construct($xenconnection, $name, $hostId)
+	{
 		parent::__construct($xenconnection);
-		$this->name = $name;
+		$this->name   = $name;
 		$this->hostId = $hostId;
 	}
 
-    /**
-     * Gets the value of name.
-     *
-     * @return mixed
-     */
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    /**
-     * Sets the value of name.
-     *
-     * @param mixed $name the name
-     *
-     * @return self
-     */
-    public function _setName($name)
-    {
-        $this->name = $name;
-
-        return $this;
-    }
-
-    /**
-     * Gets the value of hostId.
-     *
-     * @return mixed
-     */
-    public function getHostId()
-    {
-        return $this->hostId;
-    }
-
-    /**
-     * Sets the value of hostId.
-     *
-     * @param mixed $hostId the host id
-     *
-     * @return self
-     */
-    public function _setHostId($hostId)
-    {
-        $this->hostId = $hostId;
-
-        return $this;
-    }
+	/**
+	 * Gets the value of name.
+	 *
+	 * @return mixed
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
 
 	/**
-     * Puts the host into a state in which no new VMs can be started. Currently active VMs on the host
+	 * Sets the value of name.
+	 *
+	 * @param mixed $name the name
+	 *
+	 * @return self
+	 */
+	public function _setName($name)
+	{
+		$this->name = $name;
+
+		return $this;
+	}
+
+	/**
+	 * Gets the value of hostId.
+	 *
+	 * @return mixed
+	 */
+	public function getHostId()
+	{
+		return $this->hostId;
+	}
+
+	/**
+	 * Sets the value of hostId.
+	 *
+	 * @param mixed $hostId the host id
+	 *
+	 * @return self
+	 */
+	public function _setHostId($hostId)
+	{
+		$this->hostId = $hostId;
+
+		return $this;
+	}
+
+	/**
+	 * Puts the host into a state in which no new VMs can be started. Currently active VMs on the host
 	 * continue to execute.
-     *
-     * @param 
-     *
-     * @return mixed
-     */
-    public function disable(){
-        
-        return $this->getXenconnection()->host__disable($this->getHostId());      
-    }
+	 *
+	 * @param
+	 *
+	 * @return mixed
+	 */
+	public function disable()
+	{
+
+		return $this->getXenconnection()->host__disable($this->getHostId());
+	}
 
 	/**
-     * Puts the host into a state in which  new VMs can be started.
-     *
-     * @param 
-     *
-     * @return mixed
-     */
-    public function enable(){
-        
-        return $this->getXenconnection()->host__enable($this->getHostId());      
-    }
+	 * Puts the host into a state in which  new VMs can be started.
+	 *
+	 * @param
+	 *
+	 * @return mixed
+	 */
+	public function enable()
+	{
+
+		return $this->getXenconnection()->host__enable($this->getHostId());
+	}
 
 
 	/**
-     * Shutdown the host. (This function can only be called if there are no currently running VMs on
+	 * Shutdown the host. (This function can only be called if there are no currently running VMs on
 	 * the host and it is disabled.).
-     *
-     * @param 
-     *
-     * @return mixed
-     */
-    public function shutdown(){
-        
-        return $this->getXenconnection()->host__shutdown($this->getHostId());      
-    }
-   
+	 *
+	 * @param
+	 *
+	 * @return mixed
+	 */
+	public function shutdown()
+	{
+
+		return $this->getXenconnection()->host__shutdown($this->getHostId());
+	}
+
 	/**
-     * Reboot the host. (This function can only be called if there are no currently running VMs on
+	 * Reboot the host. (This function can only be called if there are no currently running VMs on
 	 * the host and it is disabled.).
-     *
-     * @param 
-     *
-     * @return mixed
-     */
-    public function reboot(){
-        
-        return $this->getXenconnection()->host__reboot($this->getHostId());      
-    } 
+	 *
+	 * @param
+	 *
+	 * @return mixed
+	 */
+	public function reboot()
+	{
 
-	
-    /**
-     * Get the host xen dmesg.
-     *
-     * @param 
-     *
-     * @return mixed
-     */
-    public function dmesg(){
-        
-        return $this->getXenconnection()->host__dmesg($this->getHostId());      
-    }
-
-    /**
-     * Get the host xen dmesg, and clear the buffer
-     *
-     * @param 
-     *
-     * @return mixed
-     */
-    public function dmesgClear(){
-        
-        return $this->getXenconnection()->host__dmesg_clear($this->getHostId());      
-    }
-
-    /**
-     * Get the host’s log file.
-     *
-     * @param 
-     *
-     * @return mixed
-     */
-    public function getLog(){
-        
-        return $this->getXenconnection()->host__get_log($this->getHostId());      
-    }
-
-   /**
-     * List all supported methods.
-     *
-     * @param 
-     *
-     * @return mixed
-     */  
-    public function listMethods(){
-        
-        return $this->getXenconnection()->host__list_methods();      
-    }
+		return $this->getXenconnection()->host__reboot($this->getHostId());
+	}
 
 
 	/**
-     * Apply a new license to a host.
-     *
-     * @param $license The contents of the license file, base64 en-coded
-     *
-     * @return mixed
-     */  
-    public function licenseApply($license = ""){
-        
-        return $this->getXenconnection()->host__license_apply($this->getHostId(),$license);      
-    }
+	 * Get the host xen dmesg.
+	 *
+	 * @param
+	 *
+	 * @return mixed
+	 */
+	public function dmesg()
+	{
+
+		return $this->getXenconnection()->host__dmesg($this->getHostId());
+	}
+
+	/**
+	 * Get the host xen dmesg, and clear the buffer
+	 *
+	 * @param
+	 *
+	 * @return mixed
+	 */
+	public function dmesgClear()
+	{
+
+		return $this->getXenconnection()->host__dmesg_clear($this->getHostId());
+	}
+
+	/**
+	 * Get the host’s log file.
+	 *
+	 * @param
+	 *
+	 * @return mixed
+	 */
+	public function getLog()
+	{
+
+		return $this->getXenconnection()->host__get_log($this->getHostId());
+	}
+
+	/**
+	 * List all supported methods.
+	 *
+	 * @param
+	 *
+	 * @return mixed
+	 */
+	public function listMethods()
+	{
+
+		return $this->getXenconnection()->host__list_methods();
+	}
 
 
 	/**
-     * Check this host can be evacuated.
-     *
-     * @param 
-     *
-     * @return mixed
-     */  
-    public function assertCanEvacuate(){
-        
-        return $this->getXenconnection()->host__assert_can_evacuate($this->getHostId());      
-    } 
-    
-    /**
-     * Migrate all VMs off of this host, where possible.
-     *
-     * @param 
-     *
-     * @return mixed
-     */  
-    public function evacuate(){
-        
-        return $this->getXenconnection()->host__evacuate($this->getHostId());      
-    } 
-    
+	 * Apply a new license to a host.
+	 *
+	 * @param $license The contents of the license file, base64 en-coded
+	 *
+	 * @return mixed
+	 */
+	public function licenseApply($license = "")
+	{
 
-    /**
-     * This call queries the host’s clock for the current time.
-     *
-     * @param 
-     *
-     * @return mixed
-     */  
-    public function  getServertime(){
-        
-        return $this->getXenconnection()->host__get_servertime($this->getHostId());      
-    } 
-
-    /**
-     * This call queries the host's clock for the current time in the host’s local timezone.
-     *
-     * @param 
-     *
-     * @return mixed
-     */  
-    public function getServerLocaltime(){
-        
-        return $this->getXenconnection()->host__get_server_localtime($this->getHostId());      
-    }
-
-    /**
-     * Get the installed server SSL certificate. (pem file)
-     *
-     * @param 
-     *
-     * @return mixed
-     */  
-    public function getServerCertificate(){
-        
-        return $this->getXenconnection()->host__get_server_certificate($this->getHostId());      
-    }
+		return $this->getXenconnection()->host__license_apply($this->getHostId(), $license);
+	}
 
 
-    /**
-     * Change to another edition, or reactivate the current edition after a license has expired. This may
-     * be subject to the successful checkout of an appropriate license.
-     *
-     * @param $edition The requested edition, $force Update the license params even if the apply
-     * 		  call fails
-     *
-     * @return mixed
-     */  
-    public function applyEdition($edition,$force = false){
-        
-        return $this->getXenconnection()->host__apply_edition($this->getHostId(),$edition,$force);      
-    }
-    
+	/**
+	 * Check this host can be evacuated.
+	 *
+	 * @param
+	 *
+	 * @return mixed
+	 */
+	public function assertCanEvacuate()
+	{
 
-    /**
-     * Refresh the list of installed Supplemental Packs.
-     *
-     * @param 
-     *
-     * @return mixed
-     */  
-    public function refreshPackInfo(){
-        
-        return $this->getXenconnection()->host__refresh_pack_info($this->getHostId());      
-    }
+		return $this->getXenconnection()->host__assert_can_evacuate($this->getHostId());
+	}
 
+	/**
+	 * Migrate all VMs off of this host, where possible.
+	 *
+	 * @param
+	 *
+	 * @return mixed
+	 */
+	public function evacuate()
+	{
 
-    /**
-     * Enable the use of a local SR for caching purposes.
-     *
-     * @param string SR ref sr
-     *
-     * @return mixed
-     */  
-    public function enableLocalStorageCaching($srRef){
-        
-        return $this->getXenconnection()->host__enable_local_storage_caching($this->getHostId(),$srRef);      
-    }
+		return $this->getXenconnection()->host__evacuate($this->getHostId());
+	}
 
 
+	/**
+	 * This call queries the host’s clock for the current time.
+	 *
+	 * @param
+	 *
+	 * @return mixed
+	 */
+	public function getServertime()
+	{
 
-    /**
-     * Disable the use of a local SR for caching purposes. 	
-     *
-     * @param 
-     *
-     * @return mixed
-     */  
-    public function disableLocalStorageCaching(){
-        
-        return $this->getXenconnection()->host__disable_local_storage_caching($this->getHostId());      
-    }    
+		return $this->getXenconnection()->host__get_servertime($this->getHostId());
+	}
 
-    /**
-     * Prepare to receive a VM, returning a token which can be passed to VM.migrate. 	
-     *
-     * @param string network ref network, array features
-     *
-     * @return mixed
-     */  
-    public function migrateReceive($networkRef, $features = array()){
-        
-        return $this->getXenconnection()->host__migrate_receive($this->getHostId(),$networkRef,$features);      
-    }      
-        
-    /**
-     * Get the uuid field of the given host. 	
-     *
-     * @param 
-     *
-     * @return mixed
-     */  
-    public function getUUID(){
-    	return $this->getXenconnection()->host__get_uuid($this->getHostId());      
-    }
+	/**
+	 * This call queries the host's clock for the current time in the host’s local timezone.
+	 *
+	 * @param
+	 *
+	 * @return mixed
+	 */
+	public function getServerLocaltime()
+	{
 
-    /**
-     * Get the name/label field of the given host. 	
-     *
-     * @param 
-     *
-     * @return mixed
-     */  
-    public function getNameLabel(){
-    	return $this->getXenconnection()->host__get_name_label($this->getHostId());      
-    }  
-   
-    /**
-     * Set the name/label field of the given host. 	
-     *
-     * @param string $name
-     *
-     * @return mixed
-     */  
-    public function setNameLabel($name){
-    	return $this->getXenconnection()->host__set_name_label($this->getHostId(),$name);      
-    }    
-	
+		return $this->getXenconnection()->host__get_server_localtime($this->getHostId());
+	}
+
+	/**
+	 * Get the installed server SSL certificate. (pem file)
+	 *
+	 * @param
+	 *
+	 * @return mixed
+	 */
+	public function getServerCertificate()
+	{
+
+		return $this->getXenconnection()->host__get_server_certificate($this->getHostId());
+	}
+
+
+	/**
+	 * Change to another edition, or reactivate the current edition after a license has expired. This may
+	 * be subject to the successful checkout of an appropriate license.
+	 *
+	 * @param $edition The requested edition, $force Update the license params even if the apply
+	 *                 call fails
+	 *
+	 * @return mixed
+	 */
+	public function applyEdition($edition, $force = false)
+	{
+
+		return $this->getXenconnection()->host__apply_edition($this->getHostId(), $edition, $force);
+	}
+
+
+	/**
+	 * Refresh the list of installed Supplemental Packs.
+	 *
+	 * @param
+	 *
+	 * @return mixed
+	 */
+	public function refreshPackInfo()
+	{
+
+		return $this->getXenconnection()->host__refresh_pack_info($this->getHostId());
+	}
+
+
+	/**
+	 * Enable the use of a local SR for caching purposes.
+	 *
+	 * @param string SR ref sr
+	 *
+	 * @return mixed
+	 */
+	public function enableLocalStorageCaching($srRef)
+	{
+
+		return $this->getXenconnection()->host__enable_local_storage_caching($this->getHostId(), $srRef);
+	}
+
+
+	/**
+	 * Disable the use of a local SR for caching purposes.
+	 *
+	 * @param
+	 *
+	 * @return mixed
+	 */
+	public function disableLocalStorageCaching()
+	{
+
+		return $this->getXenconnection()->host__disable_local_storage_caching($this->getHostId());
+	}
+
+	/**
+	 * Prepare to receive a VM, returning a token which can be passed to VM.migrate.
+	 *
+	 * @param string network ref network, array features
+	 *
+	 * @return mixed
+	 */
+	public function migrateReceive($networkRef, $features = array())
+	{
+
+		return $this->getXenconnection()->host__migrate_receive($this->getHostId(), $networkRef, $features);
+	}
+
+	/**
+	 * Get the uuid field of the given host.
+	 *
+	 * @param
+	 *
+	 * @return mixed
+	 */
+	public function getUUID()
+	{
+		return $this->getXenconnection()->host__get_uuid($this->getHostId());
+	}
+
+	/**
+	 * Get the name/label field of the given host.
+	 *
+	 * @param
+	 *
+	 * @return mixed
+	 */
+	public function getNameLabel()
+	{
+		return $this->getXenconnection()->host__get_name_label($this->getHostId());
+	}
+
+	/**
+	 * Set the name/label field of the given host.
+	 *
+	 * @param string $name
+	 *
+	 * @return mixed
+	 */
+	public function setNameLabel($name)
+	{
+		return $this->getXenconnection()->host__set_name_label($this->getHostId(), $name);
+	}
+
 	/**
 	 * Get the name/description field of the given HOST.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getNameDescription(){
+	public function getNameDescription()
+	{
 		return $this->getXenconnection()->host__get_name_description($this->getHostId());
 	}
 
@@ -356,54 +380,59 @@ class XenHost extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	public function setNameDescription($name){
-		return $this->getXenconnection()->host__set_name_description($this->getHostId(),$name);
+	public function setNameDescription($name)
+	{
+		return $this->getXenconnection()->host__set_name_description($this->getHostId(), $name);
 	}
 
 	/**
 	 * Get the current operations field of the given HOST.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getCurrentOperations(){
+	public function getCurrentOperations()
+	{
 		return $this->getXenconnection()->host__get_current_operations($this->getHostId());
 	}
 
 	/**
 	 * Get the allowed operations field of the given HOST.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getAllowedOperations(){
+	public function getAllowedOperations()
+	{
 		return $this->getXenconnection()->host__get_allowed_operations($this->getHostId());
 	}
 
 	/**
 	 * Get the software version field of the given host.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getSoftwareVersion(){
+	public function getSoftwareVersion()
+	{
 		return $this->getXenconnection()->host__get_software_version($this->getHostId());
 	}
 
 	/**
 	 * Get the other config field of the given HOST.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getOtherConfig(){
+	public function getOtherConfig()
+	{
 		return $this->getXenconnection()->host__get_other_config($this->getHostId());
 	}
-	
+
 	/**
 	 * Set the other config field of the given HOST.
 	 *
@@ -411,8 +440,9 @@ class XenHost extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	public function setOtherConfig($array = array()){
-		return $this->getXenconnection()->host__set_other_config($this->getHostId(),$array);
+	public function setOtherConfig($array = array())
+	{
+		return $this->getXenconnection()->host__set_other_config($this->getHostId(), $array);
 	}
 
 	/**
@@ -422,73 +452,82 @@ class XenHost extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	public function addToOtherConfig($key,$value){
-		return $this->getXenconnection()->host__add_to_other_config($this->getHostId(),$key,$value);
+	public function addToOtherConfig($key, $value)
+	{
+		return $this->getXenconnection()->host__add_to_other_config($this->getHostId(), $key, $value);
 	}
 
 	/**
 	 * Remove the given key and its corresponding value from the other config field of the given host. If
-     * the key is not in that Map, then do nothing.
+	 * the key is not in that Map, then do nothing.
 	 *
 	 * @param $key string
 	 *
 	 * @return XenResponse $response
 	 */
-	public function removeFromOtherConfig($key){
-		return $this->getXenconnection()->host__remove_from_other_config($this->getHostId(),$key);
+	public function removeFromOtherConfig($key)
+	{
+		return $this->getXenconnection()->host__remove_from_other_config($this->getHostId(), $key);
 	}
 
 	/**
 	 * Get the supported bootloaders field of the given host.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getSupportedBootloaders(){
+	public function getSupportedBootloaders()
+	{
 		return $this->getXenconnection()->host__get_supported_bootloaders($this->getHostId());
 	}
 
 	/**
 	 * Get the resident VMs field of the given host.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getResidentVMs(){
+	public function getResidentVMs()
+	{
 		$response = $this->getXenconnection()->host__get_resident_VMs($this->getHostId());
-		$VMs = array();
-		if($response->getValue() != ""){
-			foreach ($response->getValue() as $key => $vm) {
-				$xenVM = new XenVirtualMachine($this->getXenconnection(),null,$vm);
-				$name = $xenVM->getNameLabel()->getValue();
-				array_push($VMs,new XenVirtualMachine($this->getXenconnection(),$name,$vm));
+		$VMs      = array();
+		if ($response->getValue() != "")
+		{
+			foreach ($response->getValue() as $key => $vm)
+			{
+				$xenVM = new XenVirtualMachine($this->getXenconnection(), null, $vm);
+				$name  = $xenVM->getNameLabel()->getValue();
+				array_push($VMs, new XenVirtualMachine($this->getXenconnection(), $name, $vm));
 			}
 			$response->_setValue($VMs);
 		}
+
 		return $response;
 	}
 
 	/**
 	 * Get the patches field of the given host.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getPatches(){
+	public function getPatches()
+	{
 		return $this->getXenconnection()->host__get_patches($this->getHostId());
 	}
-	
+
 	/**
 	 * Get the host CPUs field of the given host.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getHostCPUs(){
+	public function getHostCPUs()
+	{
 		return $this->getXenconnection()->host__get_host_CPUs($this->getHostId());
 	}
 
@@ -496,25 +535,27 @@ class XenHost extends XenElement {
 	/**
 	 * Get the cpu info field of the given host.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getCPUInfo(){
+	public function getCPUInfo()
+	{
 		return $this->getXenconnection()->host__get_cpu_info($this->getHostId());
-	}	
+	}
 
 	/**
 	 * Get the hostname of the given host.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getHostname(){
+	public function getHostname()
+	{
 		return $this->getXenconnection()->host__get_hostname($this->getHostId());
-	}	
-	
+	}
+
 	/**
 	 * Set the hostname of the given host.
 	 *
@@ -522,85 +563,93 @@ class XenHost extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	public function setHostname($name){
-		return $this->getXenconnection()->host__set_hostname($this->getHostId(),$name);
-	}	
+	public function setHostname($name)
+	{
+		return $this->getXenconnection()->host__set_hostname($this->getHostId(), $name);
+	}
 
 	/**
 	 * Get the address field of the given host.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getAddress(){
+	public function getAddress()
+	{
 		return $this->getXenconnection()->host__get_address($this->getHostId());
 	}
 
 	/**
-	 * Set the address field of the given host. 
+	 * Set the address field of the given host.
 	 *
 	 * @param $address string
 	 *
 	 * @return XenResponse $response
 	 */
-	public function setAddress($address){
-		return $this->getXenconnection()->host__set_address($this->getHostId(),$address);
+	public function setAddress($address)
+	{
+		return $this->getXenconnection()->host__set_address($this->getHostId(), $address);
 	}
-	
+
 	/**
-	 * Get the metrics field of the given host 
+	 * Get the metrics field of the given host
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getMetrics(){
+	public function getMetrics()
+	{
 		return $this->getXenconnection()->host__get_metrics($this->getHostId());
 	}
 
 	/**
-	 * Get the license params field of the given host. 
+	 * Get the license params field of the given host.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getLicenseParam(){
+	public function getLicenseParam()
+	{
 		return $this->getXenconnection()->host__get_license_params($this->getHostId());
 	}
 
 	/**
-	 * Get the edition field of the given host. 
+	 * Get the edition field of the given host.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getEdition(){
+	public function getEdition()
+	{
 		return $this->getXenconnection()->host__get_edition($this->getHostId());
 	}
-	
+
 	/**
 	 * Get the license server field of the given host.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getLicenseServer(){
+	public function getLicenseServer()
+	{
 		return $this->getXenconnection()->host__get_license_server($this->getHostId());
 	}
 
 	/**
-	 * Set the license server field of the given host. 
+	 * Set the license server field of the given host.
 	 *
 	 * @param $license_server string
 	 *
 	 * @return XenResponse $response
 	 */
-	public function setLicenseServer($license_server){
-		return $this->getXenconnection()->host__license_server($this->getHostId(),$license_server);
+	public function setLicenseServer($license_server)
+	{
+		return $this->getXenconnection()->host__license_server($this->getHostId(), $license_server);
 	}
 
 	/**
@@ -610,8 +659,9 @@ class XenHost extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	public function addToLicenseServer($key,$value){
-		return $this->getXenconnection()->host__add_to_license_server($this->getHostId(),$key,$value);
+	public function addToLicenseServer($key, $value)
+	{
+		return $this->getXenconnection()->host__add_to_license_server($this->getHostId(), $key, $value);
 	}
 
 	/**
@@ -622,20 +672,23 @@ class XenHost extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	public function removeFromLicenseServer($key){
-		return $this->getXenconnection()->host__remove_from_license_server($this->getHostId(),$key);
+	public function removeFromLicenseServer($key)
+	{
+		return $this->getXenconnection()->host__remove_from_license_server($this->getHostId(), $key);
 	}
 
 	/**
 	 * Get the chipset info field of the given host.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getChipsetInfo(){
+	public function getChipsetInfo()
+	{
 		return $this->getXenconnection()->host__get_chipset_info($this->getHostId());
 	}
 }
+
 ?>
 	

--- a/src/Sircamp/Xenapi/Element/XenNetwork.php
+++ b/src/Sircamp/Xenapi/Element/XenNetwork.php
@@ -3,51 +3,55 @@
 use Respect\Validation\Validator as Validator;
 use GuzzleHttp\Client as Client;
 
-class XenNetwork extends XenElement {
+class XenNetwork extends XenElement
+{
 
 	private $name;
 	private $networkId;
 
-	public function __construct($xenconnection,$name,$networkId){
+	public function __construct($xenconnection, $name, $networkId)
+	{
 		parent::__construct($xenconnection);
-		$this->name = $name;
-		$this->networkId = $hostId;
+		$this->name      = $name;
+		$this->networkId = $networkId;
 	}
 
-    /**
-     * Gets the value of name.
-     *
-     * @return mixed
-     */
-    public function getName()
-    {
-        return $this->name;
-    }
+	/**
+	 * Gets the value of name.
+	 *
+	 * @return mixed
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
 
-    /**
-     * Sets the value of name.
-     *
-     * @param mixed $name the name
-     *
-     * @return self
-     */
-    private function _setName($name)
-    {
-        $this->name = $name;
+	/**
+	 * Sets the value of name.
+	 *
+	 * @param mixed $name the name
+	 *
+	 * @return self
+	 */
+	private function _setName($name)
+	{
+		$this->name = $name;
 
-        return $this;
-    }
+		return $this;
+	}
 
 	/**
 	 * Return a list of all the Networks known to the system.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return mixed
 	 */
-	public function getAll(){
+	public function getAll()
+	{
 		return $this->getXenconnection()->network__get_all();
 	}
 }
+
 ?>
 	

--- a/src/Sircamp/Xenapi/Element/XenVirtualMachine.php
+++ b/src/Sircamp/Xenapi/Element/XenVirtualMachine.php
@@ -2,31 +2,33 @@
 
 use Respect\Validation\Validator as Validator;
 use GuzzleHttp\Client as Client;
-use Sircamp\Xenapi\Connection\XenResponse as  XenResponse;
+use Sircamp\Xenapi\Connection\XenResponse as XenResponse;
 
-class XenVirtualMachine extends XenElement {
+class XenVirtualMachine extends XenElement
+{
 
 	private $name;
 	private $vmId;
 
-	public function __construct($xenconnection,$name,$vmId){
+	public function __construct($xenconnection, $name, $vmId)
+	{
 		parent::__construct($xenconnection);
 		$this->name = $name;
 		$this->vmId = $vmId;
 	}
 
 
-	
 	/**
 	 * Return a list of all the VMs known to the system.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return mixed
 	 */
-	public function getAll(){
+	public function getAll()
+	{
 		return $this->getXenconnection()->VM__get_all();
-	}	
+	}
 
 	/**
 	 * Hard Reboot a VM by passing her uuid.
@@ -35,8 +37,9 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return mixed
 	 */
-	public function hardReboot(){
-		
+	public function hardReboot()
+	{
+
 		return $this->getXenconnection()->VM__hard_reboot($this->getVmId());
 	}
 
@@ -47,7 +50,8 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return mixed
 	 */
-	public function hardShutdown(){
+	public function hardShutdown()
+	{
 		return $this->getXenconnection()->VM__hard_shutdown($this->getVmId());
 	}
 
@@ -58,7 +62,8 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return mixed
 	 */
-	public function suspend(){
+	public function suspend()
+	{
 		return $this->getXenconnection()->VM__suspend($this->getVmId());
 	}
 
@@ -69,7 +74,8 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return mixed
 	 */
-	public function resume(){
+	public function resume()
+	{
 		return $this->getXenconnection()->VM__resume($this->getVmId());
 	}
 
@@ -81,21 +87,27 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return mixed
 	 */
-	public function resumeOn($hostRef = null){
+	public function resumeOn($hostRef = null)
+	{
 		$hostRefString = "";
-		if($hostRef == null){
+		if ($hostRef == null)
+		{
 			throw new \IllegalArgumentException("hostRef must be not NULL", 1);
-			
+
 		}
-		else{
-			if(is_object($hostRef)){
+		else
+		{
+			if (is_object($hostRef))
+			{
 				$hostRefString = $hostRef->getHostId();
 			}
-			else{
+			else
+			{
 				$hostRefString = $hostRef;
 			}
 		}
-		return $this->getXenconnection()->VM__resume_on($this->getVmId(),$hostRefString);
+
+		return $this->getXenconnection()->VM__resume_on($this->getVmId(), $hostRefString);
 	}
 
 	/**
@@ -103,58 +115,69 @@ class XenVirtualMachine extends XenElement {
 	 * state.
 	 *
 	 * @param mixed $VM the uuid of VM, $hostRef the target host
-	 *		 $optionsMap  Extra configuration operations
+	 *                  $optionsMap  Extra configuration operations
+	 *
 	 * @return mixed
 	 */
-	
-	public function poolMigrate($hostRef = null, $optionsMap = array()){
+
+	public function poolMigrate($hostRef = null, $optionsMap = array())
+	{
 		$hostRefString = "";
-		if($hostRef == null){
+		if ($hostRef == null)
+		{
 			throw new \IllegalArgumentException("hostRef must be not NULL", 1);
-			
+
 		}
-		else{
-			if(is_object($hostRef)){
+		else
+		{
+			if (is_object($hostRef))
+			{
 				$hostRefString = $hostRef->getHostId();
 			}
-			else{
+			else
+			{
 				$hostRefString = $hostRef;
 			}
 		}
-		return $this->getXenconnection()->VM__pool_migrate($this->getVmId(),$hostRefString,$optionsMap);
+
+		return $this->getXenconnection()->VM__pool_migrate($this->getVmId(), $hostRefString, $optionsMap);
 	}
 
 	/**
 	 * Migrate the VM to another host. This can only be called when the specified VM is in the Running
 	 * state.
 	 *
-	 * @param mixed $VM the uuid of VM, 
-	 *		  $def The result of a Host.migrate receive call.
-	 *		  $live The Live migration
-	 *		  $vdiMap of source VDI to destination SR
-	 *		  $vifMap of source VIF to destination network
-	 *		  $optionsMap  Extra configuration operations
+	 * @param mixed $VM the uuid of VM,
+	 *                  $def The result of a Host.migrate receive call.
+	 *                  $live The Live migration
+	 *                  $vdiMap of source VDI to destination SR
+	 *                  $vifMap of source VIF to destination network
+	 *                  $optionsMap  Extra configuration operations
+	 *
 	 * @return mixed
 	 */
 
-	public function migrateSend($dest,$vdiMap,$vifMap,$options,$live = false){
-		return $this->getXenconnection()->VM__migrate_send($this->getVmId(),$dest,$live,$vdiMap,$vifMap,$options);
+	public function migrateSend($dest, $vdiMap, $vifMap, $options, $live = false)
+	{
+		return $this->getXenconnection()->VM__migrate_send($this->getVmId(), $dest, $live, $vdiMap, $vifMap, $options);
 	}
 
 
 	/**
 	 * Assert whether a VM can be migrated to the specified destination.
 	 *
-	 * @param mixed $VM the uuid of VM, 
-	 *		  $def The result of a Host.migrate receive call.
-	 *		  $live The Live migration
-	 *		  $vdiMap of source VDI to destination SR
-	 *		  $vifMap of source VIF to destination network
-	 *		  $optionsMap  Extra configuration operations
+	 * @param mixed $VM the uuid of VM,
+	 *                  $def The result of a Host.migrate receive call.
+	 *                  $live The Live migration
+	 *                  $vdiMap of source VDI to destination SR
+	 *                  $vifMap of source VIF to destination network
+	 *                  $optionsMap  Extra configuration operations
+	 *
 	 * @return mixed
 	 */
-	public function assertCanMigrate($dest,$vdiMap,$vifMap,$options,$live = false){
-		return $this->getXenconnection()->VM__assert_can_migrate($this->getVmId(),$dest,$live,$vdiMap,$vifMap,$options);
+	public function assertCanMigrate($dest, $vdiMap, $vifMap, $options, $live = false)
+	{
+		return $this->getXenconnection()->VM__assert_can_migrate($this->getVmId(), $dest, $live, $vdiMap, $vifMap, $options);
 	}
 
 	/**
@@ -164,7 +187,8 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return mixed
 	 */
-	public function cleanReboot(){
+	public function cleanReboot()
+	{
 		return $this->getXenconnection()->VM__clean_reboot($this->getVmId());
 	}
 
@@ -175,7 +199,8 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return mixed
 	 */
-	public function cleanShutdown(){
+	public function cleanShutdown()
+	{
 		return $this->getXenconnection()->VM__clean_shutdown($this->getVmId());
 	}
 
@@ -187,7 +212,8 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return mixed
 	 */
-	public function pause(){
+	public function pause()
+	{
 		return $this->getXenconnection()->VM__pause($this->getVmId());
 	}
 
@@ -198,7 +224,8 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return mixed
 	 */
-	public function unpuse(){
+	public function unpuse()
+	{
 		return $this->getXenconnection()->VM__unpause($this->getVmId());
 	}
 
@@ -207,49 +234,55 @@ class XenVirtualMachine extends XenElement {
 	 * Start a VM by passing her uuid.
 	 *
 	 * @param mixed $VM the uuid of VM,
-	 *		  $pause Instantiate VM in paused state if set to true.
-	 *		  Attempt to force the VM to start. If this flag
-	 *		  is false then the VM may fail pre-boot safety
-     *         checks (e.g. if the CPU the VM last booted
-	 *		  on looks substantially different to the current one)
+	 *                  $pause Instantiate VM in paused state if set to true.
+	 *                  Attempt to force the VM to start. If this flag
+	 *                  is false then the VM may fail pre-boot safety
+	 *                  checks (e.g. if the CPU the VM last booted
+	 *                  on looks substantially different to the current one)
 	 *
 	 * @return mixed
 	 */
-	public function start($pause = false, $force = true){
+	public function start($pause = false, $force = true)
+	{
 
-		return $this->getXenconnection()->VM__start($this->getVmId(),$pause,$force);
+		return $this->getXenconnection()->VM__start($this->getVmId(), $pause, $force);
 	}
-	
+
 	/**
 	 * Start the specified VM on a particular host. This function can only be called with the VM is in
 	 * the Halted State.
 	 *
 	 * @param mixed $VM the uuid of VM, $hostRef the Host on which to start the VM
-	 *		  $pause Instantiate VM in paused state if set to true.
-	 *		  Attempt to force the VM to start. If this flag
-	 *		  is false then the VM may fail pre-boot safety
-     *         checks (e.g. if the CPU the VM last booted
-	 *		  on looks substantially different to the current one)
+	 *                  $pause Instantiate VM in paused state if set to true.
+	 *                  Attempt to force the VM to start. If this flag
+	 *                  is false then the VM may fail pre-boot safety
+	 *                  checks (e.g. if the CPU the VM last booted
+	 *                  on looks substantially different to the current one)
 	 *
 	 * @return mixed
 	 */
-	public function startOn($hostRef, $pause = false, $force = true){
+	public function startOn($hostRef, $pause = false, $force = true)
+	{
 
 		$hostRefString = "";
-		if($hostRef == null){
+		if ($hostRef == null)
+		{
 			throw new \IllegalArgumentException("The where you want start new machine, must be set!", 1);
-			
+
 		}
-		else{
-			if(is_object($hostRef)){
+		else
+		{
+			if (is_object($hostRef))
+			{
 				$hostRefString = $hostRef->getHostId();
 			}
-			else{
+			else
+			{
 				$hostRefString = $hostRef;
 			}
 		}
 
-		return $this->getXenconnection()->VM__start_on($this->getVmId(),$hostRefString,$pause,$force);
+		return $this->getXenconnection()->VM__start_on($this->getVmId(), $hostRefString, $pause, $force);
 	}
 
 	/**
@@ -259,21 +292,23 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return mixed
 	 */
-	public function clonevm($name){
-		return $this->getXenconnection()->VM__clone($this->getVmId(),$name);
+	public function clonevm($name)
+	{
+		return $this->getXenconnection()->VM__clone($this->getVmId(), $name);
 	}
 
 	/**
 	 * Get the UUID of a VM .
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return mixed
 	 */
-	function getUUID(){
+	function getUUID()
+	{
 		return $this->getXenconnection()->VM__get_uuid($this->getVmId());
 	}
-	
+
 	/**
 	 * Get the consoles instances a VM by passing her uuid.
 	 *
@@ -281,7 +316,8 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return mixed
 	 */
-	function getConsoles(){
+	function getConsoles()
+	{
 		return $this->getXenconnection()->VM__get_consoles($this->getVmId());
 	}
 
@@ -292,7 +328,8 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return mixed
 	 */
-	function getConsoleUUID($CN){
+	function getConsoleUUID($CN)
+	{
 		return $this->getXenconnection()->console__get_uuid($CN);
 	}
 
@@ -303,10 +340,11 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return mixed
 	 */
-	function getPowerState(){
+	function getPowerState()
+	{
 		return $this->getXenconnection()->VM__get_power_state($this->getVmId());
 	}
-	
+
 	/**
 	 * Reset the power-state of the VM to halted in the database only. (Used to recover from slave failures
 	 * in pooling scenarios by resetting the power-states of VMs running on dead slaves to halted.) This
@@ -316,10 +354,11 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return mixed
 	 */
-	function powerStateReset(){
+	function powerStateReset()
+	{
 		return $this->getXenconnection()->VM__power_state_reset($this->getVmId());
 	}
-	
+
 
 	/**
 	 * Get the VM guest metrics by passing her uuid.
@@ -328,8 +367,10 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return mixed
 	 */
-	function getGuestMetrics(){
+	function getGuestMetrics()
+	{
 		$VMG = $this->getXenconnection()->VM__get_guest_metrics($this->getVmId());
+
 		return $this->getXenconnection()->VM_guest_metrics__get_record($VMG->getValue());
 	}
 
@@ -340,9 +381,10 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return mixed
 	 */
-	function getMetrics(){
+	function getMetrics()
+	{
 		$VMG = $this->getXenconnection()->VM__get_metrics($this->getVmId());
-		
+
 		return $this->getXenconnection()->VM_metrics__get_record($VMG->getValue());
 	}
 
@@ -350,38 +392,41 @@ class XenVirtualMachine extends XenElement {
 	/**
 	 * Get the VM stats by passing her uuid.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	function getStats(){
+	function getStats()
+	{
 
-		$user = $this->getXenconnection()->getUser();
+		$user     = $this->getXenconnection()->getUser();
 		$password = $this->getXenconnection()->getPassword();
-		$ip = $this->getXenconnection()->getUrl();
-		$uuid = $this->getUUID($this->getVmId());
-		
-		$url='http://'.$user.':'.$password.'@'.$ip.'/vm_rrd?uuid='.$uuid->getValue().'&start=1000000000‏';
+		$ip       = $this->getXenconnection()->getUrl();
+		$uuid     = $this->getUUID($this->getVmId());
 
-		
+		$url = 'http://' . $user . ':' . $password . '@' . $ip . '/vm_rrd?uuid=' . $uuid->getValue() . '&start=1000000000‏';
 
-		$client = new Client();
+
+		$client   = new Client();
 		$response = $client->get($url);
-		 
+
 		$body = $response->getBody();
-        $xml ="";
-        
-        while (!$body->eof()) {
-    		$xml .= $body->read(1024);
+		$xml  = "";
+
+		while (!$body->eof())
+		{
+			$xml .= $body->read(1024);
 		}
 
-		$response = new XenResponse(array('Value'=>array(0=>'')));
+		$response = new XenResponse(array('Value' => array(0 => '')));
 
-		if(Validator::string()->validate($xml)){
-			$response = new XenResponse(array('Value'=>$xml,'Status'=>'Success'));
+		if (Validator::string()->validate($xml))
+		{
+			$response = new XenResponse(array('Value' => $xml, 'Status' => 'Success'));
 		}
-		else{
-			$response = new XenResponse(array('Value'=>'', 'Status'=>'Failed'));
+		else
+		{
+			$response = new XenResponse(array('Value' => '', 'Status' => 'Failed'));
 		}
 
 		return $response;
@@ -394,117 +439,126 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	function getDiskSpace($size = NULL){
-		$VBD = $this->getXenconnection()->VBD__get_all();
-		$memory = 0; 
-		foreach ($VBD->getValue() as $bd) {
-			$responsevm = $this->getXenconnection()->VBD__get_VM($bd);
+	function getDiskSpace($size = null)
+	{
+		$VBD    = $this->getXenconnection()->VBD__get_all();
+		$memory = 0;
+		foreach ($VBD->getValue() as $bd)
+		{
+			$responsevm   = $this->getXenconnection()->VBD__get_VM($bd);
 			$responsetype = $this->getXenconnection()->VBD__get_type($bd);
 
-			if($responsevm->getValue() == $this->getVmId() && $responsetype->getValue() == "Disk"){
-					$VDI = $this->getXenconnection()->VBD__get_VDI($bd);
-					$memory += intval($this->getXenconnection()->VDI__get_virtual_size($VDI->getValue())->getValue());	
+			if ($responsevm->getValue() == $this->getVmId() && $responsetype->getValue() == "Disk")
+			{
+				$VDI    = $this->getXenconnection()->VBD__get_VDI($bd);
+				$memory += intval($this->getXenconnection()->VDI__get_virtual_size($VDI->getValue())->getValue());
 			}
 		}
-		
-		$response = NULL;
-		if(Validator::numeric()->validate($memory)){
-			
-			return new XenResponse(array('Value'=>$memory,'Status'=>'Success'));
+
+		$response = null;
+		if (Validator::numeric()->validate($memory))
+		{
+
+			return new XenResponse(array('Value' => $memory, 'Status' => 'Success'));
 		}
-		else{
-			return new XenResponse(array('Value'=>0,'Status'=>'Failed'));
+		else
+		{
+			return new XenResponse(array('Value' => 0, 'Status' => 'Failed'));
 		}
-		
+
 		return $response;
 	}
 
-    /**
-     * Gets the value of name.
-     *
-     * @return mixed
-     */
-    public function getName()
-    {
-        return $this->name;
-    }
+	/**
+	 * Gets the value of name.
+	 *
+	 * @return mixed
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
 
-    /**
-     * Sets the value of name.
-     *
-     * @param mixed $name the name
-     *
-     * @return self
-     */
-    private function _setName($name)
-    {
-        $this->name = $name;
+	/**
+	 * Sets the value of name.
+	 *
+	 * @param mixed $name the name
+	 *
+	 * @return self
+	 */
+	private function _setName($name)
+	{
+		$this->name = $name;
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Gets the value of vmId.
-     *
-     * @return mixed
-     */
-    public function getVmId()
-    {
-        return $this->vmId;
-    }
+	/**
+	 * Gets the value of vmId.
+	 *
+	 * @return mixed
+	 */
+	public function getVmId()
+	{
+		return $this->vmId;
+	}
 
-    /**
-     * Sets the value of vmId.
-     *
-     * @param mixed $vmId the vm id
-     *
-     * @return self
-     */
-    private function _setVmId($vmId)
-    {
-        $this->vmId = $vmId;
+	/**
+	 * Sets the value of vmId.
+	 *
+	 * @param mixed $vmId the vm id
+	 *
+	 * @return self
+	 */
+	private function _setVmId($vmId)
+	{
+		$this->vmId = $vmId;
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Snapshots the specified VM, making a new VM. 
-     * Snapshot automatically exploits the capabilities of the underlying storage repository 
-     * in which the VM’s disk images are stored
-     *
-     * @param string $name the name of snapshot
-     *
-     * @return XenResponse $response
-     */
-    public function snapshot($name){
-		return $this->getXenconnection()->VM__snapshot($this->getVmId(),$name);
+	/**
+	 * Snapshots the specified VM, making a new VM.
+	 * Snapshot automatically exploits the capabilities of the underlying storage repository
+	 * in which the VM’s disk images are stored
+	 *
+	 * @param string $name the name of snapshot
+	 *
+	 * @return XenResponse $response
+	 */
+	public function snapshot($name)
+	{
+		return $this->getXenconnection()->VM__snapshot($this->getVmId(), $name);
 	}
 
 	//TOFIX
+
 	/**
-	 * Snapshots the specified VM with quiesce, making a new VM. 
-	 * Snapshot automatically exploits the capabilities of the underlying 
+	 * Snapshots the specified VM with quiesce, making a new VM.
+	 * Snapshot automatically exploits the capabilities of the underlying
 	 * storage repository in which the VM’s disk images are stored
 	 *
 	 * @param string $name the name of snapshot
 	 *
 	 * @return XenResponse $response
 	 */
-	public function snapshotWithQuiesce($name){
-		return $this->getXenconnection()->VM__snapshot_with_quiesce($this->getVmId(),$name);
+	public function snapshotWithQuiesce($name)
+	{
+		return $this->getXenconnection()->VM__snapshot_with_quiesce($this->getVmId(), $name);
 	}
 
 	/**
 	 * Get the snapshot info field of the given VM.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getSnapshotInfo(){
+	public function getSnapshotInfo()
+	{
 		return $this->getXenconnection()->VM__get_snapshot_info($this->getVmId());
 	}
-	
+
 
 	/**
 	 * Copied the specified VM, making a new VM. Unlike clone, copy does not exploits the capabilities
@@ -516,8 +570,9 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	public function copy($name){
-		return $this->getXenconnection()->VM__copy($this->getVmId(),$name,"");
+	public function copy($name)
+	{
+		return $this->getXenconnection()->VM__copy($this->getVmId(), $name, "");
 	}
 
 
@@ -529,9 +584,11 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	public function destroy(){
+	public function destroy()
+	{
 		return $this->getXenconnection()->VM__destroy($this->getVmId());
 	}
+
 	/**
 	 * Reverts the specified VM to a previous state
 	 *
@@ -539,8 +596,9 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	public function revert($snapshotID){
-		return $this->getXenconnection()->VM__revert($this->getVmId(),$snapshotID);
+	public function revert($snapshotID)
+	{
+		return $this->getXenconnection()->VM__revert($this->getVmId(), $snapshotID);
 	}
 
 	/**
@@ -552,8 +610,9 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	public function checkpoint($name){
-		return $this->getXenconnection()->VM__checkpoint($this->getVmId(),$name);
+	public function checkpoint($name)
+	{
+		return $this->getXenconnection()->VM__checkpoint($this->getVmId(), $name);
 	}
 
 
@@ -564,10 +623,11 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	public function setStartDelay($seconds){
-		return $this->getXenconnection()->VM__set_start_delay($this->getVmId(),$seconds);
+	public function setStartDelay($seconds)
+	{
+		return $this->getXenconnection()->VM__set_start_delay($this->getVmId(), $seconds);
 	}
-	
+
 	/**
 	 * Set this VM’s start delay in seconds.
 	 *
@@ -575,64 +635,69 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	public function setShutdownDelay($seconds){
-		return $this->getXenconnection()->VM__set_shutdown_delay($this->getVmId(),$seconds);
+	public function setShutdownDelay($seconds)
+	{
+		return $this->getXenconnection()->VM__set_shutdown_delay($this->getVmId(), $seconds);
 	}
 
 	/**
 	 * Get the start delay field of the given VM.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getStartDelay(){
+	public function getStartDelay()
+	{
 		return $this->getXenconnection()->VM__get_start_delay($this->getVmId());
 	}
-	
+
 	/**
 	 * Get the shutdown delay field of the given VM.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getShutdownDelay(){
+	public function getShutdownDelay()
+	{
 		return $this->getXenconnection()->VM__get_shutdown_delay($this->getVmId());
 	}
 
 	/**
 	 * Get the current operations field of the given VM.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getCurrentOperations(){
+	public function getCurrentOperations()
+	{
 		return $this->getXenconnection()->VM__get_current_operations($this->getVmId());
 	}
 
 	/**
 	 * Get the allowed operations field of the given VM.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getAllowedOperations(){
+	public function getAllowedOperations()
+	{
 		return $this->getXenconnection()->VM__get_allowed_operations($this->getVmId());
 	}
-
 
 
 	/**
 	 * Get the name/description field of the given VM.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getNameDescription(){
+	public function getNameDescription()
+	{
 		return $this->getXenconnection()->VM__get_name_description($this->getVmId());
 	}
 
@@ -643,18 +708,20 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	public function setNameDescription($name){
-		return $this->getXenconnection()->VM__set_name_description($this->getVmId(),$name);
+	public function setNameDescription($name)
+	{
+		return $this->getXenconnection()->VM__set_name_description($this->getVmId(), $name);
 	}
 
 	/**
 	 * Get the is a template field of the given VM.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getIsATemplate(){
+	public function getIsATemplate()
+	{
 		return $this->getXenconnection()->VM__get_is_a_template($this->getVmId());
 	}
 
@@ -665,39 +732,43 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	public function setIsATemplate($template){
-		return $this->getXenconnection()->VM__set_is_a_template($this->getVmId(),$template);
+	public function setIsATemplate($template)
+	{
+		return $this->getXenconnection()->VM__set_is_a_template($this->getVmId(), $template);
 	}
-
 
 
 	/**
 	 * Get the resident on field of the given VM.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getResidentOn(){
-		$xenHost = null;
+	public function getResidentOn()
+	{
+		$xenHost  = null;
 		$response = $this->getXenconnection()->VM__get_resident_on($this->getVmId());
-		if($response->getValue() != ""){
-			$xenHost = new XenHost($this->getXenconnection(),null,$response->getValue());
-			$name = $xenHost->getNameLabel()->getValue();
+		if ($response->getValue() != "")
+		{
+			$xenHost = new XenHost($this->getXenconnection(), null, $response->getValue());
+			$name    = $xenHost->getNameLabel()->getValue();
 			$xenHost->_setName($name);
 		}
 		$response->_setValue($xenHost);
+
 		return $response;
 	}
 
 	/**
 	 * Get the platform field of the given VM.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getPlatform(){
+	public function getPlatform()
+	{
 		return $this->getXenconnection()->VM__get_platform($this->getVmId());
 	}
 
@@ -709,22 +780,24 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	public function setPlatform($value = array()){
-		return $this->getXenconnection()->VM__set_platform($this->getVmId(),$value);
-	}	
-	
+	public function setPlatform($value = array())
+	{
+		return $this->getXenconnection()->VM__set_platform($this->getVmId(), $value);
+	}
+
 
 	/**
 	 * Get the other config field of the given VM.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getOtherConfig(){
+	public function getOtherConfig()
+	{
 		return $this->getXenconnection()->VM__get_other_config($this->getVmId());
 	}
-	
+
 	/**
 	 * Set the other config field of the given VM.
 	 *
@@ -732,8 +805,9 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	public function setOtherConfig($array = array()){
-		return $this->getXenconnection()->VM__set_other_config($this->getVmId(),$array);
+	public function setOtherConfig($array = array())
+	{
+		return $this->getXenconnection()->VM__set_other_config($this->getVmId(), $array);
 	}
 
 	/**
@@ -743,33 +817,37 @@ class XenVirtualMachine extends XenElement {
 	 *
 	 * @return XenResponse $response
 	 */
-	public function addToOtherConfig($key,$value){
-		return $this->getXenconnection()->VM__add_to_other_config($this->getVmId(),$key,$value);
+	public function addToOtherConfig($key, $value)
+	{
+		return $this->getXenconnection()->VM__add_to_other_config($this->getVmId(), $key, $value);
 	}
 
 	/**
 	 * Remove the given key and its corresponding value from the other config field of the given vm. If
-     * the key is not in that Map, then do nothing.
+	 * the key is not in that Map, then do nothing.
 	 *
 	 * @param $key string
 	 *
 	 * @return XenResponse $response
 	 */
-	public function removeFromOtherConfig($key){
-		return $this->getXenconnection()->VM__remove_from_other_config($this->getVmId(),$key);
+	public function removeFromOtherConfig($key)
+	{
+		return $this->getXenconnection()->VM__remove_from_other_config($this->getVmId(), $key);
 	}
 
 	/**
 	 * Get name label VM.
 	 *
-	 * @param 
+	 * @param
 	 *
 	 * @return XenResponse $response
 	 */
-	public function getNameLabel(){
+	public function getNameLabel()
+	{
 		return $this->getXenconnection()->VM__get_name_label($this->getVmId());
 	}
 
 }
+
 ?>
 	

--- a/src/Sircamp/Xenapi/Exception/XenConnectionException.php
+++ b/src/Sircamp/Xenapi/Exception/XenConnectionException.php
@@ -2,10 +2,12 @@
 
 use Exception;
 
-class XenConnectionException extends Exception {
-	
-	public function __construct($message,$code){
-		parent::__construct($message,$code);
+class XenConnectionException extends Exception
+{
+
+	public function __construct($message, $code)
+	{
+		parent::__construct($message, $code);
 	}
 }
 

--- a/src/Sircamp/Xenapi/Xen.php
+++ b/src/Sircamp/Xenapi/Xen.php
@@ -49,7 +49,7 @@ class Xen
 	 *
 	 * @return mixed
 	 */
-	public function getVMByNameLabel($name) : XenVirtualMachine
+	public function getVMByNameLabel($name): XenVirtualMachine
 	{
 		$response = new XenResponse($this->xenconnection->VM__get_by_name_label($name));
 

--- a/src/Sircamp/Xenapi/Xen.php
+++ b/src/Sircamp/Xenapi/Xen.php
@@ -1,38 +1,44 @@
 <?php namespace Sircamp\Xenapi;
+
 use Respect\Validation\Validator as Validator;
-use GuzzleHttp\Client as Client;
-use Sircamp\Xenapi\Element\XenVirtualMachine as  XenVirtualMachine;
+use Sircamp\Xenapi\Connection\XenConnection as XenConnection;
+use Sircamp\Xenapi\Connection\XenResponse as XenResponse;
 use Sircamp\Xenapi\Element\XenHost as XenHost;
-use Sircamp\Xenapi\Connection\XenConnection as  XenConnection;
-use Sircamp\Xenapi\Connection\XenResponse as  XenResponse;
-use Sircamp\Xenapi\Exception as  XenConnectionException;
+use Sircamp\Xenapi\Element\XenVirtualMachine as XenVirtualMachine;
 
-class Xen {
+class Xen
+{
 
-	private $xenconnection = NULL;
+	private $xenconnection = null;
 
-	public function __construct($url, $user, $password){
+	public function __construct($url, $user, $password)
+	{
 
-		
-		if(! Validator::ip()->validate($url)){
+
+		if (!Validator::ip()->validate($url))
+		{
 
 			throw new \InvalidArgumentException("'url' value mast be an ipv4 address", 1);
-			
+
 		}
-		if(!Validator::string()->validate($user)){
+		if (!Validator::stringType()->validate($user))
+		{
 			throw new \InvalidArgumentException("'user' value mast be an non empty string", 1);
 		}
 
-		if(!Validator::string()->validate($password)){
+		if (!Validator::stringType()->validate($password))
+		{
 			throw new \InvalidArgumentException("'password' value mast be an non empty string", 1);
 		}
-		
+
 		$this->xenconnection = new XenConnection();
-		try{
-			$this->xenconnection->_setServer($url,$user,$password);
+		try
+		{
+			$this->xenconnection->_setServer($url, $user, $password);
 		}
-		catch(Exception $e){
-			dd($e->getMessage());
+		catch (\Exception $e)
+		{
+			die($e->getMessage());
 		}
 	}
 
@@ -43,9 +49,11 @@ class Xen {
 	 *
 	 * @return mixed
 	 */
-	public function getVMByNameLabel($name){
+	public function getVMByNameLabel($name) : XenVirtualMachine
+	{
 		$response = new XenResponse($this->xenconnection->VM__get_by_name_label($name));
-		return new XenVirtualMachine($this->xenconnection,$name,$response->getValue()[0]);
+
+		return new XenVirtualMachine($this->xenconnection, $name, $response->getValue()[0]);
 	}
 
 	/**
@@ -55,11 +63,13 @@ class Xen {
 	 *
 	 * @return mixed
 	 */
-	public function getHOSTByNameLabel($name){
+	public function getHOSTByNameLabel($name)
+	{
 		$response = new XenResponse($this->xenconnection->host__get_by_name_label($name));
-		return new XenHost($this->xenconnection,$name,$response->getValue()[0]);
+
+		return new XenHost($this->xenconnection, $name, $response->getValue()[0]);
 	}
-	
+
 
 }
 


### PR DESCRIPTION
I updated the package for the use with PHP 7.
There was a conflict with the "Validator" package, because the Validator has classes like "String" which are not allowed in PHP 7. Validator has renamend the calls. The composer requires now the newest version of it.
The calls to the Validator were updated in the whole pakage.

Furthermore the code was reformatted using the PSR-0.